### PR TITLE
Fix "SqliteCodeFirst" always backs up the original table

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/CodeFirstProvider/CodeFirstProvider.cs
@@ -9,7 +9,7 @@ namespace SqlSugar
     {
         #region Properties
         public virtual SqlSugarClient Context { get; set; }
-        private bool IsBackupTable { get; set; }
+        protected bool IsBackupTable { get; set; }
         private int MaxBackupDataRows { get; set; }
         #endregion
 

--- a/Src/Asp.Net/SqlSugar/Realization/Sqlite/CodeFirst/SqliteCodeFirst.cs
+++ b/Src/Asp.Net/SqlSugar/Realization/Sqlite/CodeFirst/SqliteCodeFirst.cs
@@ -21,7 +21,8 @@ namespace SqlSugar
                     columns.Add(dbColumnInfo);
                 }
             }
-            this.Context.DbMaintenance.BackupTable(tableName, backupName, int.MaxValue);
+            if (IsBackupTable)
+                this.Context.DbMaintenance.BackupTable(tableName, backupName, int.MaxValue);
             this.Context.DbMaintenance.DropTable(tableName);
             this.Context.DbMaintenance.CreateTable(tableName,columns);
         }


### PR DESCRIPTION
Fix "SqliteCodeFirst" always backs up the original table.