### PR TITLE
修复映射实体时IL错误

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
@@ -207,7 +207,11 @@ namespace SqlSugar
                 {
                     method = getConvertValueMethod.MakeGenericMethod(columnInfo.PropertyInfo.PropertyType);
                 }
-                generator.Emit(OpCodes.Call, method);
+
+                if (method.IsVirtual)
+                    generator.Emit(OpCodes.Callvirt, method);
+                else
+                    generator.Emit(OpCodes.Call, method);
                 return;
             };
             #endregion
@@ -313,7 +317,10 @@ namespace SqlSugar
             if (method == null)
                 method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
 
-            generator.Emit(OpCodes.Call, method);
+            if (method.IsVirtual)
+                generator.Emit(OpCodes.Callvirt, method);
+            else
+                generator.Emit(OpCodes.Call, method);
             #endregion
         }
 


### PR DESCRIPTION
fix #444 #348 

在 .NET Core 3.0 preview3 后，在 IL 中调用接口方法需要显式的使用 `OpCodes.Callvirt` 而不是 `OpCodes.Call`。

相关issue与PR：https://github.com/dotnet/coreclr/issues/24330 https://github.com/dotnet/coreclr/pull/23032

cc @sunkaixuan 

@dj2792 @xmlijia 可以测试一下