### PR TITLE
修复DbFirst模式下，生成实体时，Guid的bug

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/DbFirstProvider/DbFirstProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/DbFirstProvider/DbFirstProvider.cs
@@ -417,7 +417,7 @@ namespace SqlSugar
                 return convertString;
             if (convertString.ObjToString() == "newid()")
             {
-                return "Guid.NewGuid()";
+                return "Guid.NewGuid().ToString()";
             }
             if (item.DataType == "bit")
                 return (convertString == "1" || convertString.Equals("true", StringComparison.CurrentCultureIgnoreCase)).ToString().ToLower();

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbFirstProvider/DbFirstProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbFirstProvider/DbFirstProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -417,7 +417,7 @@ namespace SqlSugar
                 return convertString;
             if (convertString.ObjToString() == "newid()")
             {
-                return "Guid.NewGuid()";
+                return "Guid.NewGuid().ToString()";
             }
             if (item.DataType == "bit")
                 return (convertString == "1" || convertString.Equals("true", StringComparison.CurrentCultureIgnoreCase)).ToString().ToLower();


### PR DESCRIPTION
当DbFirst模式下， 生成业务实体时，当如果数据库类型是Guid时，默认值是string,但目前代码生成的默认值类型是Guid类型，造成生成的业务实体，无法编译通过