### PR TITLE
使用Select()时存在数据字段到对象的映射错误

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MemberInitExpressionResolve.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MemberInitExpressionResolve.cs
@@ -223,7 +223,7 @@ namespace SqlSugar
                     throw new NotSupportedException();
                 }
                 MemberAssignment memberAssignment = (MemberAssignment)binding;
-                var memberName = memberAssignment.Member.Name;
+                var memberName = Context.GetDbColumnName(expression.Type.Name, memberAssignment.Member.Name);
                 var item = memberAssignment.Expression;
                 ResolveNewExpressions(parameter, item, memberName);
             }


### PR DESCRIPTION
fix #551 

cc: @sunkaixuan 
我认为对类进行Select可以不用生成AS别名，这只是一个暂时性的修复，如果你对此问题有更好的解决办法，请关闭此PR