### PR TITLE
兼容可空枚举列（Nullable<enum>），使得新增和修改可空枚举列时不会将结果存为0.

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/InsertableProvider/InsertableProvider.cs
@@ -397,9 +397,10 @@ namespace SqlSugar
                     DbColumnName = GetDbColumnName(column.PropertyName),
                     PropertyName = column.PropertyName,
                     PropertyType = UtilMethods.GetUnderType(column.PropertyInfo),
-                    TableId = i
+                    TableId = i,
+                    IsNullable = column.IsNullable
                 };
-                if (columnInfo.PropertyType.IsEnum())
+                if (columnInfo.PropertyType.IsEnum() && !column.IsNullable)
                 {
                     columnInfo.Value = Convert.ToInt64(columnInfo.Value);
                 }

--- a/Src/Asp.Net/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
@@ -480,9 +480,10 @@ namespace SqlSugar
                     DbColumnName = GetDbColumnName(column.PropertyName),
                     PropertyName = column.PropertyName,
                     PropertyType = UtilMethods.GetUnderType(column.PropertyInfo),
-                    TableId = i
+                    TableId = i,
+                    IsNullable = column.IsNullable
                 };
-                if (columnInfo.PropertyType.IsEnum())
+                if (columnInfo.PropertyType.IsEnum() && !column.IsNullable)
                 {
                     columnInfo.Value = Convert.ToInt64(columnInfo.Value);
                 }


### PR DESCRIPTION
现版本发现的问题，对于可空类型的枚举字段，保存时即使 **State = null**，也会在数据库中存入 **0** 。
```csharp
public enum MyEnum { Good = 1, Bad = 2 }
public class Table1 {
    public Guid Id { get; set; }
    public MyEnum? State { get; set; } // <- 可空字段
}
```
因此增加了 `IsNullable` 的双重判断，使得可空枚举类型存储结果还是 **null**。
即不会执行 `columnInfo.Value = Convert.ToInt64(columnInfo.Value);` 这段转换代码。