### PR TITLE
增强· 实体包含IsJson列 无法使用SetColumns方式更新部分字段问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/MySqlTest/UnitTest/UJson.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/MySqlTest/UnitTest/UJson.cs
@@ -17,8 +17,13 @@ namespace OrmTest
             var list = Db.Queryable<UnitJsonTest>().ToList();
             UValidate.Check("order1", list.First().Order.Name, "Json");
             Db.Updateable(new UnitJsonTest() { Id = 1, Order = new Order { Id = 2, Name = "order2" } }).ExecuteCommand();
-            list= Db.Queryable<UnitJsonTest>().ToList();
+            list = Db.Queryable<UnitJsonTest>().ToList();
             UValidate.Check("order2", list.First().Order.Name, "Json");
+
+            Db.Updateable<UnitJsonTest>().SetColumns(x => new UnitJsonTest { Order = new Order { Id = 2, Name = "order3" } }).Where(x => x.Id == 1).ExecuteCommand();
+            list = Db.Queryable<UnitJsonTest>().ToList();
+            UValidate.Check("order3", list.First().Order.Name, "Json");
+
             var list2 = Db.Queryable<UnitJsonTest>().ToList();
         }
     }

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/UpdateProvider/UpdateableProvider.cs
@@ -64,7 +64,7 @@ namespace SqlSugar
         public async Task<int> ExecuteCommandAsync()
         {
             string sql = _ExecuteCommand();
-            var result =await this.Ado.ExecuteCommandAsync(sql, UpdateBuilder.Parameters == null ? null : UpdateBuilder.Parameters.ToArray());
+            var result = await this.Ado.ExecuteCommandAsync(sql, UpdateBuilder.Parameters == null ? null : UpdateBuilder.Parameters.ToArray());
             After(sql);
             return result;
         }
@@ -119,7 +119,7 @@ namespace SqlSugar
 
 
 
-        public IUpdateable<T> IgnoreColumns(bool ignoreAllNullColumns, bool isOffIdentity = false,bool ignoreAllDefaultValue = false)
+        public IUpdateable<T> IgnoreColumns(bool ignoreAllNullColumns, bool isOffIdentity = false, bool ignoreAllDefaultValue = false)
         {
             Check.Exception(this.UpdateObjs.Count() > 1 && ignoreAllNullColumns, ErrorMessage.GetThrowMessage("ignoreNullColumn NoSupport batch insert", "ignoreNullColumn 不支持批量操作"));
             UpdateBuilder.IsOffIdentity = isOffIdentity;
@@ -136,11 +136,11 @@ namespace SqlSugar
             this.UpdateBuilder.DbColumnInfoList = this.UpdateBuilder.DbColumnInfoList.Where(it => !ignoreColumns.Contains(it.DbColumnName.ToLower())).ToList();
             return this;
         }
-        public IUpdateable<T> IgnoreColumns(string [] columns)
+        public IUpdateable<T> IgnoreColumns(string[] columns)
         {
             if (columns.HasValue())
             {
-                var ignoreColumns = columns.Select(it => it.ToLower()).ToList() ;
+                var ignoreColumns = columns.Select(it => it.ToLower()).ToList();
                 this.UpdateBuilder.DbColumnInfoList = this.UpdateBuilder.DbColumnInfoList.Where(it => !ignoreColumns.Contains(it.PropertyName.ToLower())).ToList();
                 this.UpdateBuilder.DbColumnInfoList = this.UpdateBuilder.DbColumnInfoList.Where(it => !ignoreColumns.Contains(it.DbColumnName.ToLower())).ToList();
             }
@@ -156,7 +156,7 @@ namespace SqlSugar
             LambdaExpression lambda = setValueExpression as LambdaExpression;
             var expression = lambda.Body;
             Check.Exception(!(expression is BinaryExpression), "Expression  format error");
-            Check.Exception( (expression as BinaryExpression).NodeType!=ExpressionType.Equal, "Expression  format error");
+            Check.Exception((expression as BinaryExpression).NodeType != ExpressionType.Equal, "Expression  format error");
             var leftExpression = (expression as BinaryExpression).Left;
             Check.Exception(!(leftExpression is MemberExpression), "Expression  format error");
             var leftResultString = UpdateBuilder.GetExpressionValue(leftExpression, ResolveExpressType.FieldSingle).GetString();
@@ -234,8 +234,8 @@ namespace SqlSugar
                     UpdateBuilder.SetValues.Add(new KeyValuePair<string, string>(SqlBuilder.GetTranslationColumnName(key), value));
                 }
             }
-            this.UpdateBuilder.DbColumnInfoList = UpdateBuilder.DbColumnInfoList.Where(it => (UpdateParameterIsNull==false&&IsPrimaryKey(it)) || UpdateBuilder.SetValues.Any(v => SqlBuilder.GetNoTranslationColumnName(v.Key).Equals(it.DbColumnName, StringComparison.CurrentCultureIgnoreCase) || SqlBuilder.GetNoTranslationColumnName(v.Key).Equals(it.PropertyName, StringComparison.CurrentCultureIgnoreCase)) || it.IsPrimarykey == true).ToList();
-            CheckTranscodeing();
+            this.UpdateBuilder.DbColumnInfoList = UpdateBuilder.DbColumnInfoList.Where(it => (UpdateParameterIsNull == false && IsPrimaryKey(it)) || UpdateBuilder.SetValues.Any(v => SqlBuilder.GetNoTranslationColumnName(v.Key).Equals(it.DbColumnName, StringComparison.CurrentCultureIgnoreCase) || SqlBuilder.GetNoTranslationColumnName(v.Key).Equals(it.PropertyName, StringComparison.CurrentCultureIgnoreCase)) || it.IsPrimarykey == true).ToList();
+            CheckTranscodeing(false);
             AppendSets();
             return this;
         }
@@ -261,7 +261,7 @@ namespace SqlSugar
                 UpdateColumns(columns);
             return this;
         }
-        public IUpdateable<T> UpdateColumnsIF(bool isUpdateColumns, string [] columns)
+        public IUpdateable<T> UpdateColumnsIF(bool isUpdateColumns, string[] columns)
         {
             if (isUpdateColumns)
                 UpdateColumns(columns);
@@ -385,7 +385,7 @@ namespace SqlSugar
             {
                 var keys = UpdateBuilder.SetValues.Select(it => SqlBuilder.GetNoTranslationColumnName(it.Key.ToLower())).ToList();
                 var addKeys = keys.Where(k => !this.UpdateBuilder.DbColumnInfoList.Any(it => it.PropertyName.ToLower() == k || it.DbColumnName.ToLower() == k)).ToList();
-                var addItems = this.EntityInfo.Columns.Where(it =>!GetPrimaryKeys().Any(p=>p.ToLower()==it.PropertyName?.ToLower()|| p.ToLower() == it.DbColumnName?.ToLower()) && addKeys.Any(k => it.PropertyName?.ToLower() == k || it.DbColumnName?.ToLower() == k)).ToList();
+                var addItems = this.EntityInfo.Columns.Where(it => !GetPrimaryKeys().Any(p => p.ToLower() == it.PropertyName?.ToLower() || p.ToLower() == it.DbColumnName?.ToLower()) && addKeys.Any(k => it.PropertyName?.ToLower() == k || it.DbColumnName?.ToLower() == k)).ToList();
                 this.UpdateBuilder.DbColumnInfoList.AddRange(addItems.Select(it => new DbColumnInfo() { PropertyName = it.PropertyName, DbColumnName = it.DbColumnName }));
             }
             SetColumnsIndex++;
@@ -438,13 +438,13 @@ namespace SqlSugar
                 ++i;
             }
         }
-        private void CheckTranscodeing()
+        private void CheckTranscodeing(bool checkIsJson = true)
         {
             if (this.EntityInfo.Columns.Any(it => it.IsTranscoding))
             {
                 Check.Exception(true, ErrorMessage.GetThrowMessage("UpdateColumns no support IsTranscoding", "SetColumns方式更新不支持IsTranscoding，你可以使用db.Updateable(实体)的方式更新"));
             }
-            if (this.EntityInfo.Columns.Any(it => it.IsJson))
+            if (checkIsJson && this.EntityInfo.Columns.Any(it => it.IsJson))
             {
                 Check.Exception(true, ErrorMessage.GetThrowMessage("UpdateColumns no support IsJson", "SetColumns方式更新不支持IsJson，你可以使用db.Updateable(实体)的方式更新"));
             }
@@ -618,7 +618,7 @@ namespace SqlSugar
                 this.Context.MappingTables = OldMappingTableList;
             }
         }
- 
+
 
         private void ValidateVersion()
         {
@@ -705,7 +705,7 @@ namespace SqlSugar
         }
         private bool IsPrimaryKey(DbColumnInfo it)
         {
-            var result= GetPrimaryKeys().Any(p => p.Equals(it.DbColumnName, StringComparison.CurrentCultureIgnoreCase) || p.Equals(it.PropertyName, StringComparison.CurrentCultureIgnoreCase));
+            var result = GetPrimaryKeys().Any(p => p.Equals(it.DbColumnName, StringComparison.CurrentCultureIgnoreCase) || p.Equals(it.PropertyName, StringComparison.CurrentCultureIgnoreCase));
             return result;
         }
 

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MemberInitExpressionResolve.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MemberInitExpressionResolve.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -51,6 +52,22 @@ namespace SqlSugar
                 var type = expression.Type;
                 var memberName = this.Context.GetDbColumnName(type.Name, memberAssignment.Member.Name);
                 var item = memberAssignment.Expression;
+
+                //Column IsJson Handler
+                if (memberAssignment.Member.CustomAttributes != null)
+                {
+                    var customAttribute = memberAssignment.Member.GetCustomAttribute<SugarColumn>();
+
+                    if (customAttribute?.IsJson ?? false)
+                    {
+                        var paramterValue = ExpressionTool.DynamicInvoke(item);
+                        var parameterName = AppendParameter(JsonConvert.SerializeObject(paramterValue));
+                        this.Context.Result.Append(base.Context.GetEqString(memberName, parameterName));
+
+                        continue;
+                    }
+                }
+
                 if ((item is MemberExpression) && ((MemberExpression)item).Expression == null)
                 {
                     var paramterValue = ExpressionTool.DynamicInvoke(item);


### PR DESCRIPTION
解决实体类字段如果含有IsJson标记，无法使用 SetColumns 只更新部分字段。

支持更新部分列或多列(含IsJson列)。

[单元测试示例](https://github.com/oTcom/SqlSugar/blob/e1ba061baab40e66a344b51664296d22fa017bb9/Src/Asp.NetCore2/SqlSeverTest/MySqlTest/UnitTest/UJson.cs#L23-L25)