### PR TITLE
当实体类的属性为结构体时的赋值问题

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataReaderEntityBuilder.cs
@@ -241,10 +241,6 @@ namespace SqlSugar
                 case CSharpDataType.@string:
                     CheckType(bind.StringThrow, bindProperyTypeName, validPropertyName, propertyName);
                     method = getString;
-                    if (bindProperyTypeName == "guid")
-                    {
-                        method = isNullableType ? getConvertStringGuid : getStringGuid;
-                    }
                     break;
                 case CSharpDataType.DateTime:
                     CheckType(bind.DateThrow, bindProperyTypeName, validPropertyName, propertyName);
@@ -316,9 +312,14 @@ namespace SqlSugar
             {
                 method = getConvertValueMethod.MakeGenericMethod(bindPropertyType);
             }
-            if (method == null)
+            if (validPropertyType == CSharpDataType.@string && bindPropertyType.IsValueType)
+            {
                 method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
-
+            }
+            if (method == null)
+            {
+                method = isNullableType ? getOtherNull.MakeGenericMethod(bindPropertyType) : getOther.MakeGenericMethod(bindPropertyType);
+            }
             if (method.IsVirtual)
                 generator.Emit(OpCodes.Callvirt, method);
             else


### PR DESCRIPTION
当实体类的属性为结构体时,例如Point,在数据库中是以字符串的格式存储,可以通过实现PointTypeConverter类,并增加Point类的特性[TypeConverter(typeof(PointTypeConverter))]来实现赋值,因为Guid自带TypeConverter,不需要对Guid的特殊处理