### PR TITLE
数据库字段类型是字符串类型, 实体是DateTime类型，转换函数增强

### DIFF
--- a/Src/Asp.Net/SqlSugar/Abstract/DbBindProvider/IDataRecordExtensions.cs
+++ b/Src/Asp.Net/SqlSugar/Abstract/DbBindProvider/IDataRecordExtensions.cs
@@ -53,13 +53,26 @@ namespace SqlSugar
 
         public static DateTime? GetConvertDateTime(this IDataRecord dr, int i)
         {
-            var result = dr.GetDateTime(i);
-            if (result == DateTime.MinValue)
+            var value = dr.GetValue(i);
+
+            if (value == DBNull.Value)
             {
-                return null; ;
+                return null;
             }
-            return result;
+
+            if (value is DateTime result)
+            {
+                if (result == DateTime.MinValue)
+                {
+                    return null;
+                }
+
+                return result;
+            }
+
+            return Convert.ToDateTime(value.ToString());
         }
+
         public static DateTime? GetConvertTime(this IDataRecord dr, int i)
         {
             var result = dr.GetValue(i);

--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataRecordExtensions.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/Abstract/DbBindProvider/IDataRecordExtensions.cs
@@ -53,12 +53,24 @@ namespace SqlSugar
 
         public static DateTime? GetConvertDateTime(this IDataRecord dr, int i)
         {
-            var result = dr.GetDateTime(i);
-            if (result == DateTime.MinValue)
+            var value = dr.GetValue(i);
+
+            if (value == DBNull.Value)
             {
-                return null; ;
+                return null;
             }
-            return result;
+
+            if (value is DateTime result)
+            {
+                if (result == DateTime.MinValue)
+                {
+                    return null;
+                }
+
+                return result;
+            }
+
+            return Convert.ToDateTime(value.ToString());
         }
         public static DateTime? GetConvertTime(this IDataRecord dr, int i)
         {


### PR DESCRIPTION
在 SQL Server 中 如果数据库类型 是 char 或者 其他字字符串类型，实体是DateTime 类型，则会报转换错误， 对GetConvertDateTime 转换增强，不影响其他功能和性能