### PR TITLE
fix( MemberInitExpressionResolve ) 查询实体映射失败

### DIFF
--- a/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MemberInitExpressionResolve.cs
+++ b/Src/Asp.NetCore2/SqlSeverTest/SqlSugar/ExpressionsToSql/ResolveItems/MemberInitExpressionResolve.cs
@@ -84,9 +84,9 @@ namespace SqlSugar
                 {
                     try
                     {
-                        parameter.Context.Result.Append(base.Context.GetEqString(memberName,AppendParameter(ExpressionTool.DynamicInvoke(item).ObjToBool())));
+                        parameter.Context.Result.Append(base.Context.GetEqString(memberName, AppendParameter(ExpressionTool.DynamicInvoke(item).ObjToBool())));
                     }
-                    catch  
+                    catch
                     {
                         throw new NotSupportedException(item.ToString());
                     }
@@ -107,7 +107,7 @@ namespace SqlSugar
                         this.Context.Result.Append(base.Context.GetEqString(memberName, parameterName));
                     }
                 }
-                else if (IsConst(item)&&IsConvert(item)&&UtilMethods.IsNullable(item.Type) && UtilMethods.GetUnderType(item.Type)==UtilConstants.BoolType)
+                else if (IsConst(item) && IsConvert(item) && UtilMethods.IsNullable(item.Type) && UtilMethods.GetUnderType(item.Type) == UtilConstants.BoolType)
                 {
                     item = (item as UnaryExpression).Operand;
                     parameter.Context.Result.Append(base.Context.GetEqString(memberName, GetNewExpressionValue(item)));
@@ -188,7 +188,8 @@ namespace SqlSugar
                     base.Expression = item;
                     base.Start();
                     var subSql = base.Context.GetEqString(memberName, parameter.CommonTempData.ObjToString());
-                    if (subSql.Contains(",")) {
+                    if (subSql.Contains(","))
+                    {
                         subSql = subSql.Replace(",", UtilConstants.ReplaceCommaKey);
                     }
                     if (ResolveExpressType.Update == this.Context.ResolveType)
@@ -204,7 +205,7 @@ namespace SqlSugar
                         }
                     }
                     parameter.Context.Result.Append(subSql);
-                });        
+                });
             }
             else
             {
@@ -223,7 +224,17 @@ namespace SqlSugar
                     throw new NotSupportedException();
                 }
                 MemberAssignment memberAssignment = (MemberAssignment)binding;
-                var memberName = memberAssignment.Member.Name;
+                var memberName = "";
+                var sugarColumn = memberAssignment.Member.GetCustomAttributes(typeof(SugarColumn), true).Where(it => it is SugarColumn)
+                .Select(it => (SugarColumn)it).FirstOrDefault();
+                if (sugarColumn.IsNullOrEmpty())
+                {
+                    memberName = memberAssignment.Member.Name;
+                }
+                else
+                {
+                    memberName = sugarColumn.ColumnName;
+                }
                 var item = memberAssignment.Expression;
                 ResolveNewExpressions(parameter, item, memberName);
             }


### PR DESCRIPTION
fix #736
修复属性名称和数据库表字段不一致时查询实体映射失败的bug
在指令栏位查询时 （ db.Queryable().Select(selector) ） 实体无法映射。
在源码断点跟踪时发现，生成的sql 语句使用了实体的Member.Name
例如： select appId from app
实际上数据库想要的是 select app_id from app