### PR TITLE
Update MemberExpressionResolve.cs

### DIFF
--- a/Src/Asp.Net/SqlSugar/ExpressionsToSql/ResolveItems/MemberExpressionResolve.cs
+++ b/Src/Asp.Net/SqlSugar/ExpressionsToSql/ResolveItems/MemberExpressionResolve.cs
@@ -254,6 +254,12 @@ namespace SqlSugar
             }
             else
             {
+                if (null == value)
+                {
+                    parameter.BaseParameter.ValueIsNull = true;
+                    value = this.Context.DbMehtods.Null();
+
+                }
                 AppendValue(parameter, isLeft, value);
             }
         }


### PR DESCRIPTION
修复值结果为null是 sql结果为“= null”，正确为 “ is null”  报错问题 修复日期为2020-08-21  修改者;风痕